### PR TITLE
Update import for go-yaml.

### DIFF
--- a/src/srvdir/client/config.go
+++ b/src/srvdir/client/config.go
@@ -4,8 +4,8 @@ package client
 
 import (
 	"fmt"
-	"github.com/go-yaml/go-yaml-v1"
 	"github.com/inconshreveable/go-tunnel/log"
+	"gopkg.in/yaml.v1"
 	"io/ioutil"
 	"os"
 	"os/user"


### PR DESCRIPTION
When trying to build I ran into the following error:

```
src/github.com/go-yaml/go-yaml-v1/error.go:4: "ERROR: the correct import path is gopkg.in/yaml.v1 ... " evaluated but not used
```

This pull request simply updates the import path.
